### PR TITLE
feat: add FreezableNonUpgradeable

### DIFF
--- a/src/components/freezable/Freezable.sol
+++ b/src/components/freezable/Freezable.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.26;
 import { AccessControlUpgradeable } from "../../../lib/common/lib/openzeppelin-contracts-upgradeable/contracts/access/AccessControlUpgradeable.sol";
 
 import { IFreezable } from "./IFreezable.sol";
+import { FreezableCore } from "./FreezableCore.sol";
 
 abstract contract FreezableStorageLayout {
     /// @custom:storage-location erc7201:M0.storage.Freezable
@@ -24,22 +25,18 @@ abstract contract FreezableStorageLayout {
 }
 
 /**
- * @title Freezable
+ * @title  Freezable
  * @notice Upgradeable contract that allows for the freezing of accounts.
- * @dev This contract is used to prevent certain accounts from interacting with the contract.
+ * @dev    This contract is used to prevent certain accounts from interacting with the contract.
+ *         Uses ERC-7201 namespaced storage for upgrade safety.
  * @author M0 Labs
  */
-abstract contract Freezable is IFreezable, FreezableStorageLayout, AccessControlUpgradeable {
-    /* ============ Variables ============ */
-
-    /// @inheritdoc IFreezable
-    bytes32 public constant FREEZE_MANAGER_ROLE = keccak256("FREEZE_MANAGER_ROLE");
-
+abstract contract Freezable is FreezableCore, FreezableStorageLayout, AccessControlUpgradeable {
     /* ============ Initializer ============ */
 
     /**
      * @notice Initializes the contract with the given freeze manager.
-     * @param freezeManager The address of a freeze manager.
+     * @param  freezeManager The address of a freeze manager.
      */
     function __Freezable_init(address freezeManager) internal onlyInitializing {
         if (freezeManager == address(0)) revert ZeroFreezeManager();
@@ -49,12 +46,12 @@ abstract contract Freezable is IFreezable, FreezableStorageLayout, AccessControl
     /* ============ Interactive Functions ============ */
 
     /// @inheritdoc IFreezable
-    function freeze(address account) external virtual onlyRole(FREEZE_MANAGER_ROLE) {
+    function freeze(address account) external virtual override onlyRole(FREEZE_MANAGER_ROLE) {
         _freeze(_getFreezableStorageLocation(), account);
     }
 
     /// @inheritdoc IFreezable
-    function freezeAccounts(address[] calldata accounts) external virtual onlyRole(FREEZE_MANAGER_ROLE) {
+    function freezeAccounts(address[] calldata accounts) external virtual override onlyRole(FREEZE_MANAGER_ROLE) {
         FreezableStorageStruct storage $ = _getFreezableStorageLocation();
         for (uint256 i; i < accounts.length; ++i) {
             _freeze($, accounts[i]);
@@ -62,12 +59,12 @@ abstract contract Freezable is IFreezable, FreezableStorageLayout, AccessControl
     }
 
     /// @inheritdoc IFreezable
-    function unfreeze(address account) external onlyRole(FREEZE_MANAGER_ROLE) {
+    function unfreeze(address account) external override onlyRole(FREEZE_MANAGER_ROLE) {
         _unfreeze(_getFreezableStorageLocation(), account);
     }
 
     /// @inheritdoc IFreezable
-    function unfreezeAccounts(address[] calldata accounts) external onlyRole(FREEZE_MANAGER_ROLE) {
+    function unfreezeAccounts(address[] calldata accounts) external override onlyRole(FREEZE_MANAGER_ROLE) {
         FreezableStorageStruct storage $ = _getFreezableStorageLocation();
 
         for (uint256 i; i < accounts.length; ++i) {
@@ -78,30 +75,16 @@ abstract contract Freezable is IFreezable, FreezableStorageLayout, AccessControl
     /* ============ View/Pure Functions ============ */
 
     /// @inheritdoc IFreezable
-    function isFrozen(address account) public view returns (bool) {
+    function isFrozen(address account) public view virtual override returns (bool) {
         return _getFreezableStorageLocation().isFrozen[account];
     }
-
-    /* ============ Hooks For Internal Interactive Functions ============ */
-
-    /**
-     * @dev   Hook called before freezing an account.
-     * @param account   The account to be frozen.
-     */
-    function _beforeFreeze(address account) internal virtual {}
-
-    /**
-     * @dev    Hook called before unfreezing an account.
-     * @param  account   The account to be unfrozen.
-     */
-    function _beforeUnfreeze(address account) internal virtual {}
 
     /* ============ Internal Interactive Functions ============ */
 
     /**
      * @notice Internal function that freezes an account.
-     * @param $ The storage location of the freezable contract.
-     * @param account The account to freeze.
+     * @param  $ The storage location of the freezable contract.
+     * @param  account The account to freeze.
      */
     function _freeze(FreezableStorageStruct storage $, address account) internal {
         // Return early if the account is already frozen
@@ -116,8 +99,8 @@ abstract contract Freezable is IFreezable, FreezableStorageLayout, AccessControl
 
     /**
      * @notice Internal function that unfreezes an account.
-     * @param $ The storage location of the freezable contract.
-     * @param account The account to unfreeze.
+     * @param  $ The storage location of the freezable contract.
+     * @param  account The account to unfreeze.
      */
     function _unfreeze(FreezableStorageStruct storage $, address account) internal {
         // Return early if the account is not frozen
@@ -134,39 +117,29 @@ abstract contract Freezable is IFreezable, FreezableStorageLayout, AccessControl
 
     /**
      * @notice Internal function that reverts if an account is frozen.
-     * @dev Called by inheriting contracts to check if an account is frozen.
-     * @param $ The storage location of the freezable contract.
-     * @param account The account to check.
+     * @param  $ The storage location of the freezable contract.
+     * @param  account The account to check.
      */
-    function _revertIfFrozen(FreezableStorageStruct storage $, address account) internal view {
+    function _revertIfFrozen(FreezableStorageStruct storage $, address account) internal view virtual {
         if ($.isFrozen[account]) revert AccountFrozen(account);
     }
 
-    /**
-     * @notice Internal function that reverts if an account is frozen.
-     * @dev Called by inheriting contracts to check if an account is frozen.
-     * @param account The account to check.
-     */
-    function _revertIfFrozen(address account) internal view {
+    /// @inheritdoc FreezableCore
+    function _revertIfFrozen(address account) internal view virtual override {
         if (_getFreezableStorageLocation().isFrozen[account]) revert AccountFrozen(account);
     }
 
     /**
      * @notice Internal function that reverts if an account is not frozen.
-     * @dev Called by inheriting contracts to check if an account is not frozen.
-     * @param $ The storage location of the freezable contract.
-     * @param account The account to check.
+     * @param  $ The storage location of the freezable contract.
+     * @param  account The account to check.
      */
-    function _revertIfNotFrozen(FreezableStorageStruct storage $, address account) internal view {
+    function _revertIfNotFrozen(FreezableStorageStruct storage $, address account) internal view virtual {
         if (!$.isFrozen[account]) revert AccountNotFrozen(account);
     }
 
-    /**
-     * @notice Internal function that reverts if an account is not frozen.
-     * @dev Called by inheriting contracts to check if an account is not frozen.
-     * @param account The account to check.
-     */
-    function _revertIfNotFrozen(address account) internal view {
+    /// @inheritdoc FreezableCore
+    function _revertIfNotFrozen(address account) internal view virtual override {
         if (!_getFreezableStorageLocation().isFrozen[account]) revert AccountNotFrozen(account);
     }
 }

--- a/src/components/freezable/FreezableCore.sol
+++ b/src/components/freezable/FreezableCore.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+pragma solidity ^0.8.26;
+
+import { IFreezable } from "./IFreezable.sol";
+
+/**
+ * @title  FreezableCore
+ * @notice Abstract, access-control-agnostic base for freezable contracts.
+ *         Provides the FREEZE_MANAGER_ROLE constant, virtual public API, hooks,
+ *         and helper functions. Each concrete variant (upgradeable / non-upgradeable)
+ *         inherits from this and supplies its own access-control guard and storage.
+ * @author M0 Labs
+ */
+abstract contract FreezableCore is IFreezable {
+    /* ============ Variables ============ */
+
+    /// @inheritdoc IFreezable
+    bytes32 public constant FREEZE_MANAGER_ROLE = keccak256("FREEZE_MANAGER_ROLE");
+
+    /* ============ Interactive Functions ============ */
+
+    /// @inheritdoc IFreezable
+    function freeze(address account) external virtual;
+
+    /// @inheritdoc IFreezable
+    function freezeAccounts(address[] calldata accounts) external virtual;
+
+    /// @inheritdoc IFreezable
+    function unfreeze(address account) external virtual;
+
+    /// @inheritdoc IFreezable
+    function unfreezeAccounts(address[] calldata accounts) external virtual;
+
+    /* ============ View/Pure Functions ============ */
+
+    /// @inheritdoc IFreezable
+    function isFrozen(address account) public view virtual returns (bool);
+
+    /* ============ Hooks ============ */
+
+    /**
+     * @dev   Hook called before freezing an account.
+     * @param account The account to be frozen.
+     */
+    function _beforeFreeze(address account) internal virtual {}
+
+    /**
+     * @dev   Hook called before unfreezing an account.
+     * @param account The account to be unfrozen.
+     */
+    function _beforeUnfreeze(address account) internal virtual {}
+
+    /* ============ Internal View/Pure Functions ============ */
+
+    /**
+     * @notice Internal function that reverts if an account is frozen.
+     * @param  account The account to check.
+     */
+    function _revertIfFrozen(address account) internal view virtual;
+
+    /**
+     * @notice Internal function that reverts if an account is not frozen.
+     * @param  account The account to check.
+     */
+    function _revertIfNotFrozen(address account) internal view virtual;
+}

--- a/src/components/freezable/FreezableNonUpgradeable.sol
+++ b/src/components/freezable/FreezableNonUpgradeable.sol
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+pragma solidity ^0.8.26;
+
+import { AccessControl } from "../../../lib/common/lib/openzeppelin-contracts/contracts/access/AccessControl.sol";
+
+import { IFreezable } from "./IFreezable.sol";
+import { FreezableCore } from "./FreezableCore.sol";
+
+/**
+ * @title  FreezableNonUpgradeable
+ * @notice Non-upgradeable contract that allows for the freezing of accounts.
+ * @dev    Uses a plain mapping for storage. Intended for non-proxy contracts
+ *         where ERC-7201 namespaced storage is unnecessary.
+ * @author M0 Labs
+ */
+abstract contract FreezableNonUpgradeable is FreezableCore, AccessControl {
+    /* ============ Variables ============ */
+
+    /// @dev Whether an account is frozen.
+    mapping(address account => bool) private _frozenAccounts;
+
+    /* ============ Interactive Functions ============ */
+
+    /// @inheritdoc IFreezable
+    function freeze(address account) external virtual override onlyRole(FREEZE_MANAGER_ROLE) {
+        _freeze(account);
+    }
+
+    /// @inheritdoc IFreezable
+    function freezeAccounts(address[] calldata accounts) external virtual override onlyRole(FREEZE_MANAGER_ROLE) {
+        for (uint256 i; i < accounts.length; ++i) {
+            _freeze(accounts[i]);
+        }
+    }
+
+    /// @inheritdoc IFreezable
+    function unfreeze(address account) external override onlyRole(FREEZE_MANAGER_ROLE) {
+        _unfreeze(account);
+    }
+
+    /// @inheritdoc IFreezable
+    function unfreezeAccounts(address[] calldata accounts) external override onlyRole(FREEZE_MANAGER_ROLE) {
+        for (uint256 i; i < accounts.length; ++i) {
+            _unfreeze(accounts[i]);
+        }
+    }
+
+    /* ============ View/Pure Functions ============ */
+
+    /// @inheritdoc IFreezable
+    function isFrozen(address account) public view override returns (bool) {
+        return _frozenAccounts[account];
+    }
+
+    /* ============ Internal Interactive Functions ============ */
+
+    /**
+     * @notice Internal function that freezes an account.
+     * @param  account The account to freeze.
+     */
+    function _freeze(address account) internal {
+        if (_frozenAccounts[account]) return;
+
+        _beforeFreeze(account);
+
+        _frozenAccounts[account] = true;
+
+        emit Frozen(account, block.timestamp);
+    }
+
+    /**
+     * @notice Internal function that unfreezes an account.
+     * @param  account The account to unfreeze.
+     */
+    function _unfreeze(address account) internal {
+        if (!_frozenAccounts[account]) return;
+
+        _beforeUnfreeze(account);
+
+        _frozenAccounts[account] = false;
+
+        emit Unfrozen(account, block.timestamp);
+    }
+
+    /* ============ Internal View/Pure Functions ============ */
+
+    /// @inheritdoc FreezableCore
+    function _revertIfFrozen(address account) internal view override {
+        if (_frozenAccounts[account]) revert AccountFrozen(account);
+    }
+
+    /// @inheritdoc FreezableCore
+    function _revertIfNotFrozen(address account) internal view override {
+        if (!_frozenAccounts[account]) revert AccountNotFrozen(account);
+    }
+}

--- a/test/harness/FreezableNonUpgradeableHarness.sol
+++ b/test/harness/FreezableNonUpgradeableHarness.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity 0.8.26;
+
+import { FreezableNonUpgradeable } from "../../src/components/freezable/FreezableNonUpgradeable.sol";
+
+contract FreezableNonUpgradeableHarness is FreezableNonUpgradeable {
+    constructor(address freezeManager) {
+        _grantRole(FREEZE_MANAGER_ROLE, freezeManager);
+    }
+
+    function revertIfFrozen(address account) external view {
+        _revertIfFrozen(account);
+    }
+
+    function revertIfNotFrozen(address account) external view {
+        _revertIfNotFrozen(account);
+    }
+}

--- a/test/unit/components/freezable/FreezableNonUpgradeable.t.sol
+++ b/test/unit/components/freezable/FreezableNonUpgradeable.t.sol
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity 0.8.26;
+
+import { IAccessControl } from "../../../../lib/common/lib/openzeppelin-contracts/contracts/access/IAccessControl.sol";
+
+import { IFreezable } from "../../../../src/components/freezable/IFreezable.sol";
+
+import { FreezableNonUpgradeableHarness } from "../../../harness/FreezableNonUpgradeableHarness.sol";
+
+import { BaseUnitTest } from "../../../utils/BaseUnitTest.sol";
+
+contract FreezableNonUpgradeableUnitTests is BaseUnitTest {
+    FreezableNonUpgradeableHarness public freezable;
+
+    function setUp() public override {
+        super.setUp();
+
+        freezable = new FreezableNonUpgradeableHarness(freezeManager);
+    }
+
+    /* ============ constructor ============ */
+
+    function test_constructor() external view {
+        assertTrue(IAccessControl(address(freezable)).hasRole(FREEZE_MANAGER_ROLE, freezeManager));
+    }
+
+    /* ============ freeze ============ */
+
+    function test_freeze_onlyFreezeManager() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, alice, FREEZE_MANAGER_ROLE)
+        );
+
+        vm.prank(alice);
+        freezable.freeze(bob);
+    }
+
+    function test_freeze_returnEarlyIfFrozen() public {
+        vm.expectEmit();
+        emit IFreezable.Frozen(alice, block.timestamp);
+
+        vm.prank(freezeManager);
+        freezable.freeze(alice);
+
+        assertTrue(freezable.isFrozen(alice));
+
+        vm.prank(freezeManager);
+        freezable.freeze(alice);
+
+        assertTrue(freezable.isFrozen(alice));
+    }
+
+    function test_freeze() public {
+        vm.expectEmit();
+        emit IFreezable.Frozen(alice, block.timestamp);
+
+        vm.prank(freezeManager);
+        freezable.freeze(alice);
+
+        assertTrue(freezable.isFrozen(alice));
+    }
+
+    /* ============ freezeAccounts ============ */
+
+    function test_freezeAccounts_onlyFreezeManager() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, alice, FREEZE_MANAGER_ROLE)
+        );
+
+        vm.prank(alice);
+        freezable.freezeAccounts(accounts);
+    }
+
+    function test_freezeAccounts_returnEarlyIfFrozen() public {
+        address[] memory accounts = new address[](2);
+        accounts[0] = alice;
+        accounts[1] = alice;
+
+        vm.expectEmit();
+        emit IFreezable.Frozen(alice, block.timestamp);
+
+        vm.prank(freezeManager);
+        freezable.freezeAccounts(accounts);
+    }
+
+    function test_freezeAccounts() public {
+        for (uint256 i; i < accounts.length; ++i) {
+            vm.expectEmit();
+            emit IFreezable.Frozen(accounts[i], block.timestamp);
+        }
+
+        vm.prank(freezeManager);
+        freezable.freezeAccounts(accounts);
+
+        for (uint256 i; i < accounts.length; ++i) {
+            assertTrue(freezable.isFrozen(accounts[i]));
+        }
+    }
+
+    /* ============ unfreeze ============ */
+
+    function test_unfreeze_onlyFreezeManager() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, alice, FREEZE_MANAGER_ROLE)
+        );
+
+        vm.prank(alice);
+        freezable.unfreeze(bob);
+    }
+
+    function test_unfreeze_returnEarlyIfNotFrozen() public {
+        assertFalse(freezable.isFrozen(alice));
+
+        vm.prank(freezeManager);
+        freezable.unfreeze(alice);
+
+        assertFalse(freezable.isFrozen(alice));
+    }
+
+    function test_unfreeze() public {
+        vm.prank(freezeManager);
+        freezable.freeze(alice);
+
+        assertTrue(freezable.isFrozen(alice));
+
+        vm.expectEmit();
+        emit IFreezable.Unfrozen(alice, block.timestamp);
+
+        vm.prank(freezeManager);
+        freezable.unfreeze(alice);
+
+        assertFalse(freezable.isFrozen(alice));
+    }
+
+    /* ============ unfreezeAccounts ============ */
+
+    function test_unfreezeAccounts_onlyFreezeManager() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, alice, FREEZE_MANAGER_ROLE)
+        );
+
+        vm.prank(alice);
+        freezable.unfreezeAccounts(accounts);
+    }
+
+    function test_unfreezeAccounts_returnEarlyIfNotFrozen() public {
+        vm.prank(freezeManager);
+        freezable.freeze(alice);
+
+        assertTrue(freezable.isFrozen(alice));
+        assertFalse(freezable.isFrozen(bob));
+
+        address[] memory accounts = new address[](2);
+        accounts[0] = alice;
+        accounts[1] = bob;
+
+        vm.expectEmit();
+        emit IFreezable.Unfrozen(alice, block.timestamp);
+
+        vm.prank(freezeManager);
+        freezable.unfreezeAccounts(accounts);
+
+        assertFalse(freezable.isFrozen(alice));
+        assertFalse(freezable.isFrozen(bob));
+    }
+
+    function test_unfreezeAccounts() public {
+        vm.prank(freezeManager);
+        freezable.freezeAccounts(accounts);
+
+        for (uint256 i; i < accounts.length; ++i) {
+            vm.expectEmit();
+            emit IFreezable.Unfrozen(accounts[i], block.timestamp);
+        }
+
+        vm.prank(freezeManager);
+        freezable.unfreezeAccounts(accounts);
+
+        for (uint256 i; i < accounts.length; ++i) {
+            assertFalse(freezable.isFrozen(accounts[i]));
+        }
+    }
+
+    /* ============ _revertIfFrozen ============ */
+
+    function test_revertIfFrozen() public {
+        vm.prank(freezeManager);
+        freezable.freeze(alice);
+
+        assertTrue(freezable.isFrozen(alice));
+
+        vm.expectRevert(abi.encodeWithSelector(IFreezable.AccountFrozen.selector, alice));
+
+        freezable.revertIfFrozen(alice);
+    }
+
+    /* ============ _revertIfNotFrozen ============ */
+
+    function test_revertIfNotFrozen() public {
+        assertFalse(freezable.isFrozen(alice));
+
+        vm.expectRevert(abi.encodeWithSelector(IFreezable.AccountNotFrozen.selector, alice));
+
+        freezable.revertIfNotFrozen(alice);
+    }
+}


### PR DESCRIPTION
- Extract shared logic into FreezableCore abstract base
- Add FreezableNonUpgradeable using plain mapping storage
- Refactor Freezable to inherit from FreezableCore
- Use @inheritdoc IFreezable on public functions
- Add harness and 15 unit tests for non-upgradeable variant