### PR TITLE
feat(deploy): decouple proxy admin from contract admin in extension deploys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,12 +47,17 @@ export SONEIUM_TESTNET_VERIFIER_URL="https://soneium-minato.blockscout.com/api"
 # Extension-specific deployment configuration
 # Uncomment and set the variables for the extension you want to deploy
 
+# ADMIN is granted DEFAULT_ADMIN_ROLE on the extension contract (role manager).
+# PROXY_ADMIN owns the TransparentUpgradeableProxy's ProxyAdmin (upgrade authority).
+# The two MUST be set explicitly; set them to the same address if you want a single admin.
+
 # MEarnerManager Extension
 # export PREDICTED_ADDRESS=
 # export CONTRACT_NAME=
 # export EXTENSION_NAME=
 # export EXTENSION_SYMBOL=
 # export ADMIN=
+# export PROXY_ADMIN=
 # export EARNER_MANAGER=
 # export FEE_RECIPIENT=
 # export PAUSER=
@@ -64,6 +69,7 @@ export SONEIUM_TESTNET_VERIFIER_URL="https://soneium-minato.blockscout.com/api"
 # export EXTENSION_SYMBOL=
 # export YIELD_RECIPIENT=
 # export ADMIN=
+# export PROXY_ADMIN=
 # export FREEZE_MANAGER=
 # export YIELD_RECIPIENT_MANAGER=
 # export PAUSER=
@@ -75,6 +81,7 @@ export SONEIUM_TESTNET_VERIFIER_URL="https://soneium-minato.blockscout.com/api"
 # export EXTENSION_SYMBOL=
 # export YIELD_RECIPIENT=
 # export ADMIN=
+# export PROXY_ADMIN=
 # export FREEZE_MANAGER=
 # export YIELD_RECIPIENT_MANAGER=
 # export PAUSER=
@@ -87,6 +94,7 @@ export SONEIUM_TESTNET_VERIFIER_URL="https://soneium-minato.blockscout.com/api"
 # export EXTENSION_SYMBOL=
 # export YIELD_RECIPIENT=
 # export ADMIN=
+# export PROXY_ADMIN=
 # export ASSET_CAP_MANAGER=
 # export FREEZE_MANAGER=
 # export PAUSER=
@@ -100,6 +108,7 @@ export SONEIUM_TESTNET_VERIFIER_URL="https://soneium-minato.blockscout.com/api"
 # export FEE_RATE=
 # export FEE_RECIPIENT=
 # export ADMIN=
+# export PROXY_ADMIN=
 # export FEE_MANAGER=
 # export CLAIM_RECIPIENT_MANAGER=
 # export FREEZE_MANAGER=

--- a/.env.example
+++ b/.env.example
@@ -48,7 +48,9 @@ export SONEIUM_TESTNET_VERIFIER_URL="https://soneium-minato.blockscout.com/api"
 # Uncomment and set the variables for the extension you want to deploy
 
 # ADMIN is granted DEFAULT_ADMIN_ROLE on the extension contract (role manager).
-# PROXY_ADMIN owns the TransparentUpgradeableProxy's ProxyAdmin (upgrade authority).
+# PROXY_ADMIN_OWNER is the EOA/multisig that owns each extension's ProxyAdmin contract
+# (i.e., the upgrade authority). Set this to the *owner address*, NOT to a ProxyAdmin
+# contract address logged from a previous deployment.
 # The two MUST be set explicitly; set them to the same address if you want a single admin.
 
 # MEarnerManager Extension
@@ -57,7 +59,7 @@ export SONEIUM_TESTNET_VERIFIER_URL="https://soneium-minato.blockscout.com/api"
 # export EXTENSION_NAME=
 # export EXTENSION_SYMBOL=
 # export ADMIN=
-# export PROXY_ADMIN=
+# export PROXY_ADMIN_OWNER=
 # export EARNER_MANAGER=
 # export FEE_RECIPIENT=
 # export PAUSER=
@@ -69,7 +71,7 @@ export SONEIUM_TESTNET_VERIFIER_URL="https://soneium-minato.blockscout.com/api"
 # export EXTENSION_SYMBOL=
 # export YIELD_RECIPIENT=
 # export ADMIN=
-# export PROXY_ADMIN=
+# export PROXY_ADMIN_OWNER=
 # export FREEZE_MANAGER=
 # export YIELD_RECIPIENT_MANAGER=
 # export PAUSER=
@@ -81,7 +83,7 @@ export SONEIUM_TESTNET_VERIFIER_URL="https://soneium-minato.blockscout.com/api"
 # export EXTENSION_SYMBOL=
 # export YIELD_RECIPIENT=
 # export ADMIN=
-# export PROXY_ADMIN=
+# export PROXY_ADMIN_OWNER=
 # export FREEZE_MANAGER=
 # export YIELD_RECIPIENT_MANAGER=
 # export PAUSER=
@@ -94,7 +96,7 @@ export SONEIUM_TESTNET_VERIFIER_URL="https://soneium-minato.blockscout.com/api"
 # export EXTENSION_SYMBOL=
 # export YIELD_RECIPIENT=
 # export ADMIN=
-# export PROXY_ADMIN=
+# export PROXY_ADMIN_OWNER=
 # export ASSET_CAP_MANAGER=
 # export FREEZE_MANAGER=
 # export PAUSER=
@@ -108,7 +110,7 @@ export SONEIUM_TESTNET_VERIFIER_URL="https://soneium-minato.blockscout.com/api"
 # export FEE_RATE=
 # export FEE_RECIPIENT=
 # export ADMIN=
-# export PROXY_ADMIN=
+# export PROXY_ADMIN_OWNER=
 # export FEE_MANAGER=
 # export CLAIM_RECIPIENT_MANAGER=
 # export FREEZE_MANAGER=

--- a/script/Config.sol
+++ b/script/Config.sol
@@ -17,6 +17,7 @@ contract Config {
         string extensionName; // ERC20 name
         string symbol;
         address admin;
+        address proxyAdmin;
         address earnerManager;
         address feeRecipient;
         address pauser;
@@ -28,6 +29,7 @@ contract Config {
         string symbol;
         address yieldRecipient;
         address admin;
+        address proxyAdmin;
         address freezeManager;
         address yieldRecipientManager;
         address pauser;
@@ -39,6 +41,7 @@ contract Config {
         string symbol;
         address yieldRecipient;
         address admin;
+        address proxyAdmin;
         address freezeManager;
         address yieldRecipientManager;
         address pauser;
@@ -51,6 +54,7 @@ contract Config {
         string symbol;
         address yieldRecipient;
         address admin;
+        address proxyAdmin;
         address assetCapManager;
         address freezeManager;
         address pauser;
@@ -64,6 +68,7 @@ contract Config {
         uint16 feeRate;
         address feeRecipient;
         address admin;
+        address proxyAdmin;
         address feeManager;
         address claimRecipientManager;
         address freezeManager;

--- a/script/Config.sol
+++ b/script/Config.sol
@@ -17,7 +17,7 @@ contract Config {
         string extensionName; // ERC20 name
         string symbol;
         address admin;
-        address proxyAdmin;
+        address proxyAdminOwner;
         address earnerManager;
         address feeRecipient;
         address pauser;
@@ -29,7 +29,7 @@ contract Config {
         string symbol;
         address yieldRecipient;
         address admin;
-        address proxyAdmin;
+        address proxyAdminOwner;
         address freezeManager;
         address yieldRecipientManager;
         address pauser;
@@ -41,7 +41,7 @@ contract Config {
         string symbol;
         address yieldRecipient;
         address admin;
-        address proxyAdmin;
+        address proxyAdminOwner;
         address freezeManager;
         address yieldRecipientManager;
         address pauser;
@@ -54,7 +54,7 @@ contract Config {
         string symbol;
         address yieldRecipient;
         address admin;
-        address proxyAdmin;
+        address proxyAdminOwner;
         address assetCapManager;
         address freezeManager;
         address pauser;
@@ -68,7 +68,7 @@ contract Config {
         uint16 feeRate;
         address feeRecipient;
         address admin;
-        address proxyAdmin;
+        address proxyAdminOwner;
         address feeManager;
         address claimRecipientManager;
         address freezeManager;

--- a/script/deploy/DeployBase.s.sol
+++ b/script/deploy/DeployBase.s.sol
@@ -109,7 +109,7 @@ contract DeployBase is DeployHelpers, ScriptBase {
 
         proxy = _deployCreate3TransparentProxy(
             implementation,
-            extensionConfig.admin,
+            extensionConfig.proxyAdmin,
             abi.encodeWithSelector(
                 MEarnerManager.initialize.selector,
                 extensionConfig.extensionName,
@@ -137,7 +137,7 @@ contract DeployBase is DeployHelpers, ScriptBase {
 
         proxy = _deployCreate3TransparentProxy(
             implementation,
-            extensionConfig.admin,
+            extensionConfig.proxyAdmin,
             abi.encodeWithSelector(
                 MYieldToOne.initialize.selector,
                 extensionConfig.extensionName,
@@ -164,7 +164,7 @@ contract DeployBase is DeployHelpers, ScriptBase {
 
         proxy = _deployCreate3TransparentProxy(
             implementation,
-            extensionConfig.admin,
+            extensionConfig.proxyAdmin,
             abi.encodeWithSelector(
                 MYieldToOneForcedTransfer.initialize.selector,
                 extensionConfig.extensionName,
@@ -192,7 +192,7 @@ contract DeployBase is DeployHelpers, ScriptBase {
 
         proxy = _deployCreate3TransparentProxy(
             implementation,
-            extensionConfig.admin,
+            extensionConfig.proxyAdmin,
             abi.encodeWithSelector(
                 JMIExtension.initialize.selector,
                 extensionConfig.extensionName,
@@ -233,7 +233,7 @@ contract DeployBase is DeployHelpers, ScriptBase {
     ) private returns (address proxy) {
         proxy = _deployCreate3TransparentProxy(
             implementation,
-            extensionConfig.admin,
+            extensionConfig.proxyAdmin,
             abi.encodeWithSelector(
                 MYieldFee.initialize.selector,
                 extensionConfig.extensionName,

--- a/script/deploy/DeployBase.s.sol
+++ b/script/deploy/DeployBase.s.sol
@@ -109,7 +109,7 @@ contract DeployBase is DeployHelpers, ScriptBase {
 
         proxy = _deployCreate3TransparentProxy(
             implementation,
-            extensionConfig.proxyAdmin,
+            extensionConfig.proxyAdminOwner,
             abi.encodeWithSelector(
                 MEarnerManager.initialize.selector,
                 extensionConfig.extensionName,
@@ -137,7 +137,7 @@ contract DeployBase is DeployHelpers, ScriptBase {
 
         proxy = _deployCreate3TransparentProxy(
             implementation,
-            extensionConfig.proxyAdmin,
+            extensionConfig.proxyAdminOwner,
             abi.encodeWithSelector(
                 MYieldToOne.initialize.selector,
                 extensionConfig.extensionName,
@@ -164,7 +164,7 @@ contract DeployBase is DeployHelpers, ScriptBase {
 
         proxy = _deployCreate3TransparentProxy(
             implementation,
-            extensionConfig.proxyAdmin,
+            extensionConfig.proxyAdminOwner,
             abi.encodeWithSelector(
                 MYieldToOneForcedTransfer.initialize.selector,
                 extensionConfig.extensionName,
@@ -192,7 +192,7 @@ contract DeployBase is DeployHelpers, ScriptBase {
 
         proxy = _deployCreate3TransparentProxy(
             implementation,
-            extensionConfig.proxyAdmin,
+            extensionConfig.proxyAdminOwner,
             abi.encodeWithSelector(
                 JMIExtension.initialize.selector,
                 extensionConfig.extensionName,
@@ -233,7 +233,7 @@ contract DeployBase is DeployHelpers, ScriptBase {
     ) private returns (address proxy) {
         proxy = _deployCreate3TransparentProxy(
             implementation,
-            extensionConfig.proxyAdmin,
+            extensionConfig.proxyAdminOwner,
             abi.encodeWithSelector(
                 MYieldFee.initialize.selector,
                 extensionConfig.extensionName,

--- a/script/deploy/DeployJMIExtension.s.sol
+++ b/script/deploy/DeployJMIExtension.s.sol
@@ -15,6 +15,7 @@ contract DeployJMIExtension is DeployBase {
         extensionConfig.symbol = vm.envString("EXTENSION_SYMBOL");
         extensionConfig.yieldRecipient = vm.envAddress("YIELD_RECIPIENT");
         extensionConfig.admin = vm.envAddress("ADMIN");
+        extensionConfig.proxyAdmin = vm.envAddress("PROXY_ADMIN");
         extensionConfig.assetCapManager = vm.envAddress("ASSET_CAP_MANAGER");
         extensionConfig.freezeManager = vm.envAddress("FREEZE_MANAGER");
         extensionConfig.pauser = vm.envAddress("PAUSER");

--- a/script/deploy/DeployJMIExtension.s.sol
+++ b/script/deploy/DeployJMIExtension.s.sol
@@ -15,7 +15,7 @@ contract DeployJMIExtension is DeployBase {
         extensionConfig.symbol = vm.envString("EXTENSION_SYMBOL");
         extensionConfig.yieldRecipient = vm.envAddress("YIELD_RECIPIENT");
         extensionConfig.admin = vm.envAddress("ADMIN");
-        extensionConfig.proxyAdmin = vm.envAddress("PROXY_ADMIN");
+        extensionConfig.proxyAdminOwner = vm.envAddress("PROXY_ADMIN_OWNER");
         extensionConfig.assetCapManager = vm.envAddress("ASSET_CAP_MANAGER");
         extensionConfig.freezeManager = vm.envAddress("FREEZE_MANAGER");
         extensionConfig.pauser = vm.envAddress("PAUSER");

--- a/script/deploy/DeployMEarnerManager.s.sol
+++ b/script/deploy/DeployMEarnerManager.s.sol
@@ -14,6 +14,7 @@ contract DeployMEarnerManager is DeployBase {
         extensionConfig.extensionName = vm.envString("EXTENSION_NAME");
         extensionConfig.symbol = vm.envString("EXTENSION_SYMBOL");
         extensionConfig.admin = vm.envAddress("ADMIN");
+        extensionConfig.proxyAdmin = vm.envAddress("PROXY_ADMIN");
         extensionConfig.earnerManager = vm.envAddress("EARNER_MANAGER");
         extensionConfig.feeRecipient = vm.envAddress("FEE_RECIPIENT");
         extensionConfig.pauser = vm.envAddress("PAUSER");

--- a/script/deploy/DeployMEarnerManager.s.sol
+++ b/script/deploy/DeployMEarnerManager.s.sol
@@ -14,7 +14,7 @@ contract DeployMEarnerManager is DeployBase {
         extensionConfig.extensionName = vm.envString("EXTENSION_NAME");
         extensionConfig.symbol = vm.envString("EXTENSION_SYMBOL");
         extensionConfig.admin = vm.envAddress("ADMIN");
-        extensionConfig.proxyAdmin = vm.envAddress("PROXY_ADMIN");
+        extensionConfig.proxyAdminOwner = vm.envAddress("PROXY_ADMIN_OWNER");
         extensionConfig.earnerManager = vm.envAddress("EARNER_MANAGER");
         extensionConfig.feeRecipient = vm.envAddress("FEE_RECIPIENT");
         extensionConfig.pauser = vm.envAddress("PAUSER");

--- a/script/deploy/DeployYieldToAllWithFee.s.sol
+++ b/script/deploy/DeployYieldToAllWithFee.s.sol
@@ -16,6 +16,7 @@ contract DeployYieldToAllWithFee is DeployBase {
         extensionConfig.feeRate = uint16(vm.envUint("FEE_RATE"));
         extensionConfig.feeRecipient = vm.envAddress("FEE_RECIPIENT");
         extensionConfig.admin = vm.envAddress("ADMIN");
+        extensionConfig.proxyAdmin = vm.envAddress("PROXY_ADMIN");
         extensionConfig.feeManager = vm.envAddress("FEE_MANAGER");
         extensionConfig.claimRecipientManager = vm.envAddress("CLAIM_RECIPIENT_MANAGER");
         extensionConfig.freezeManager = vm.envAddress("FREEZE_MANAGER");

--- a/script/deploy/DeployYieldToAllWithFee.s.sol
+++ b/script/deploy/DeployYieldToAllWithFee.s.sol
@@ -16,7 +16,7 @@ contract DeployYieldToAllWithFee is DeployBase {
         extensionConfig.feeRate = uint16(vm.envUint("FEE_RATE"));
         extensionConfig.feeRecipient = vm.envAddress("FEE_RECIPIENT");
         extensionConfig.admin = vm.envAddress("ADMIN");
-        extensionConfig.proxyAdmin = vm.envAddress("PROXY_ADMIN");
+        extensionConfig.proxyAdminOwner = vm.envAddress("PROXY_ADMIN_OWNER");
         extensionConfig.feeManager = vm.envAddress("FEE_MANAGER");
         extensionConfig.claimRecipientManager = vm.envAddress("CLAIM_RECIPIENT_MANAGER");
         extensionConfig.freezeManager = vm.envAddress("FREEZE_MANAGER");

--- a/script/deploy/DeployYieldToOne.s.sol
+++ b/script/deploy/DeployYieldToOne.s.sol
@@ -15,6 +15,7 @@ contract DeployYieldToOne is DeployBase {
         extensionConfig.symbol = vm.envString("EXTENSION_SYMBOL");
         extensionConfig.yieldRecipient = vm.envAddress("YIELD_RECIPIENT");
         extensionConfig.admin = vm.envAddress("ADMIN");
+        extensionConfig.proxyAdmin = vm.envAddress("PROXY_ADMIN");
         extensionConfig.freezeManager = vm.envAddress("FREEZE_MANAGER");
         extensionConfig.yieldRecipientManager = vm.envAddress("YIELD_RECIPIENT_MANAGER");
         extensionConfig.pauser = vm.envAddress("PAUSER");

--- a/script/deploy/DeployYieldToOne.s.sol
+++ b/script/deploy/DeployYieldToOne.s.sol
@@ -15,7 +15,7 @@ contract DeployYieldToOne is DeployBase {
         extensionConfig.symbol = vm.envString("EXTENSION_SYMBOL");
         extensionConfig.yieldRecipient = vm.envAddress("YIELD_RECIPIENT");
         extensionConfig.admin = vm.envAddress("ADMIN");
-        extensionConfig.proxyAdmin = vm.envAddress("PROXY_ADMIN");
+        extensionConfig.proxyAdminOwner = vm.envAddress("PROXY_ADMIN_OWNER");
         extensionConfig.freezeManager = vm.envAddress("FREEZE_MANAGER");
         extensionConfig.yieldRecipientManager = vm.envAddress("YIELD_RECIPIENT_MANAGER");
         extensionConfig.pauser = vm.envAddress("PAUSER");

--- a/script/deploy/DeployYieldToOneForcedTransfer.s.sol
+++ b/script/deploy/DeployYieldToOneForcedTransfer.s.sol
@@ -15,6 +15,7 @@ contract DeployYieldToOneForcedTransfer is DeployBase {
         extensionConfig.symbol = vm.envString("EXTENSION_SYMBOL");
         extensionConfig.yieldRecipient = vm.envAddress("YIELD_RECIPIENT");
         extensionConfig.admin = vm.envAddress("ADMIN");
+        extensionConfig.proxyAdmin = vm.envAddress("PROXY_ADMIN");
         extensionConfig.freezeManager = vm.envAddress("FREEZE_MANAGER");
         extensionConfig.yieldRecipientManager = vm.envAddress("YIELD_RECIPIENT_MANAGER");
         extensionConfig.pauser = vm.envAddress("PAUSER");

--- a/script/deploy/DeployYieldToOneForcedTransfer.s.sol
+++ b/script/deploy/DeployYieldToOneForcedTransfer.s.sol
@@ -15,7 +15,7 @@ contract DeployYieldToOneForcedTransfer is DeployBase {
         extensionConfig.symbol = vm.envString("EXTENSION_SYMBOL");
         extensionConfig.yieldRecipient = vm.envAddress("YIELD_RECIPIENT");
         extensionConfig.admin = vm.envAddress("ADMIN");
-        extensionConfig.proxyAdmin = vm.envAddress("PROXY_ADMIN");
+        extensionConfig.proxyAdminOwner = vm.envAddress("PROXY_ADMIN_OWNER");
         extensionConfig.freezeManager = vm.envAddress("FREEZE_MANAGER");
         extensionConfig.yieldRecipientManager = vm.envAddress("YIELD_RECIPIENT_MANAGER");
         extensionConfig.pauser = vm.envAddress("PAUSER");


### PR DESCRIPTION
## Summary

- Adds a new required `proxyAdminOwner` field to all 5 extension config structs (`MEarnerManagerConfig`, `YieldToOneConfig`, `YieldToOneForcedTransferConfig`, `JMIExtensionConfig`, `YieldToAllWithFeeConfig`) in `script/Config.sol` and threads it through the matching helpers in `script/deploy/DeployBase.s.sol` so it becomes the `initialOwner` arg of the OZ `TransparentUpgradeableProxy` — decoupled from the contract's `DEFAULT_ADMIN_ROLE`. Named `proxyAdminOwner` (not `proxyAdmin`) to avoid a collision with the existing local `address proxyAdmin = Upgrades.getAdminAddress(proxy)` in the same helpers, which refers to the ProxyAdmin **contract** rather than its owner.
- Each per-extension deploy script now reads `PROXY_ADMIN_OWNER` from the env via `vm.envAddress` (no fallback): a missing `PROXY_ADMIN_OWNER` reverts the script before any tx is broadcast.
- `SwapFacility` / `DeployConfig` are intentionally untouched — those are M0-controlled per chain, not configured per-issuer.

## Why

We're seeing increasing demand from issuers to decouple the proxy admin from `DEFAULT_ADMIN_ROLE` and assign them to different addresses. Today the only way to express this is to hand-edit `DeployBase.s.sol` and hardcode a literal at the proxy call site (see the prior `Moonpay Proxy Admin` hardcode pattern). This makes the split a first-class config field instead.

## Breaking change for deploy runbooks

Existing runbooks that only set `ADMIN` will now revert. Every extension deploy from this point forward must export `PROXY_ADMIN_OWNER` as well. Setting `PROXY_ADMIN_OWNER` to the same address as `ADMIN` reproduces the prior single-admin behavior for deploys that genuinely want one address for both roles.

> **Operator note:** `PROXY_ADMIN_OWNER` is the EOA/multisig that *owns* the ProxyAdmin contract — **not** the ProxyAdmin contract address itself (such addresses appear in console logs of prior deployments as `"…ProxyAdmin: 0x…"`). Supplying a ProxyAdmin contract address here would hand upgrade authority to whoever owns that contract.

## Test plan

- [x] `forge build` clean
- [x] `make tests` — 451/451 passing across 19 suites (pre-commit hook)
- [ ] Reviewer: confirm `PROXY_ADMIN_OWNER` env var is documented in deploy runbooks before next mainnet deploy
- [ ] Reviewer: spot-check `script/deploy/DeployBase.s.sol` — proxy `initialOwner` arg is `extensionConfig.proxyAdminOwner` at lines 112, 140, 167, 195, 236; `extensionConfig.admin` is preserved inside every `initialize.selector` ABI encoding