### PR TITLE
feat: add scripts to enable earning and propose permissioned extensions on SwapFacility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -275,6 +275,35 @@ deploy-swap-facility-0g: deploy-swap-facility
 
 #
 #
+# CONFIGURE (Post-deployment config actions)
+#
+#
+
+enable-earning:
+	FOUNDRY_PROFILE=production PRIVATE_KEY=$(PRIVATE_KEY) EXTENSION_ADDRESS=$(EXTENSION_ADDRESS) \
+	forge script script/execute/EnableEarning.s.sol:EnableEarning \
+	--rpc-url $(RPC_URL) \
+	--private-key $(PRIVATE_KEY) \
+	--skip test --slow --non-interactive $(BROADCAST_ONLY_FLAGS)
+
+set-permissioned-extension:
+	FOUNDRY_PROFILE=production PRIVATE_KEY=$(PRIVATE_KEY) SWAP_FACILITY_ADDRESS=$(SWAP_FACILITY_ADDRESS) \
+	EXTENSION_ADDRESS=$(EXTENSION_ADDRESS) SAFE_ADDRESS=$(SAFE_ADDRESS) \
+	forge script script/execute/ProposeSetPermissionedExtension.s.sol:ProposeSetPermissionedExtension \
+	--rpc-url $(RPC_URL) \
+	--private-key $(PRIVATE_KEY) \
+	--skip test --slow --non-interactive $(BROADCAST_ONLY_FLAGS)
+
+set-permissioned-mswapper:
+	FOUNDRY_PROFILE=production PRIVATE_KEY=$(PRIVATE_KEY) SWAP_FACILITY_ADDRESS=$(SWAP_FACILITY_ADDRESS) \
+	EXTENSION_ADDRESS=$(EXTENSION_ADDRESS) SWAPPER_ADDRESS=$(SWAPPER_ADDRESS) SAFE_ADDRESS=$(SAFE_ADDRESS) \
+	forge script script/execute/ProposeSetPermissionedMSwapper.s.sol:ProposeSetPermissionedMSwapper \
+	--rpc-url $(RPC_URL) \
+	--private-key $(PRIVATE_KEY) \
+	--skip test --slow --non-interactive $(BROADCAST_ONLY_FLAGS)
+
+#
+#
 # UPGRADE
 #
 #

--- a/script/execute/EnableEarning.s.sol
+++ b/script/execute/EnableEarning.s.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity 0.8.26;
+
+import { console } from "../../lib/forge-std/src/console.sol";
+import { ScriptBase } from "../ScriptBase.s.sol";
+import { IMExtension } from "../../src/interfaces/IMExtension.sol";
+
+/**
+ * @title EnableEarning
+ * @notice Script to enable earning on a deployed MExtension contract.
+ * @dev Requires env vars: PRIVATE_KEY, EXTENSION_ADDRESS
+ *      Usage: make enable-earning RPC_URL=<rpc> EXTENSION_ADDRESS=<proxy>
+ */
+contract EnableEarning is ScriptBase {
+    function run() external {
+        address extensionAddress = vm.envAddress("EXTENSION_ADDRESS");
+
+        console.log("Enabling earning on extension:", extensionAddress);
+        console.log("Chain ID:", block.chainid);
+
+        vm.startBroadcast(vm.envUint("PRIVATE_KEY"));
+
+        IMExtension(extensionAddress).enableEarning();
+
+        vm.stopBroadcast();
+
+        console.log("Earning enabled on extension:", extensionAddress);
+    }
+}

--- a/script/execute/EnableEarning.s.sol
+++ b/script/execute/EnableEarning.s.sol
@@ -2,7 +2,8 @@
 
 pragma solidity 0.8.26;
 
-import { console } from "../../lib/forge-std/src/console.sol";
+import { console } from "forge-std/console.sol";
+
 import { ScriptBase } from "../ScriptBase.s.sol";
 import { IMExtension } from "../../src/interfaces/IMExtension.sol";
 

--- a/script/execute/ProposeSetPermissionedExtension.s.sol
+++ b/script/execute/ProposeSetPermissionedExtension.s.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity 0.8.26;
+
+import { console } from "../../lib/forge-std/src/console.sol";
+import { ScriptBase } from "../ScriptBase.s.sol";
+import { MultiSigBatchBase } from "../../lib/common/script/MultiSigBatchBase.sol";
+import { ISwapFacility } from "../../src/swap/interfaces/ISwapFacility.sol";
+
+/**
+ * @title ProposeSetPermissionedExtension
+ * @notice Proposes a multisig transaction to set an extension as permissioned on SwapFacility.
+ * @dev Requires env vars: PRIVATE_KEY, SWAP_FACILITY_ADDRESS, EXTENSION_ADDRESS, SAFE_ADDRESS
+ *      Usage: make set-permissioned-extension RPC_URL=<rpc> SWAP_FACILITY_ADDRESS=<addr> EXTENSION_ADDRESS=<addr> SAFE_ADDRESS=<addr>
+ */
+contract ProposeSetPermissionedExtension is MultiSigBatchBase {
+    function run() external {
+        address proposer_ = vm.rememberKey(vm.envUint("PRIVATE_KEY"));
+        address swapFacility_ = vm.envAddress("SWAP_FACILITY_ADDRESS");
+        address extension_ = vm.envAddress("EXTENSION_ADDRESS");
+        address safe_ = vm.envAddress("SAFE_ADDRESS");
+
+        console.log("Chain ID:", block.chainid);
+        console.log("SwapFacility:", swapFacility_);
+        console.log("Extension:", extension_);
+        console.log("Safe multisig:", safe_);
+        console.log("Proposer:", proposer_);
+
+        _addToBatch(swapFacility_, abi.encodeCall(ISwapFacility.setPermissionedExtension, (extension_, true)));
+
+        _simulateBatch(safe_);
+        _proposeBatch(safe_, proposer_);
+
+        console.log("setPermissionedExtension proposed to multisig.");
+    }
+}

--- a/script/execute/ProposeSetPermissionedExtension.s.sol
+++ b/script/execute/ProposeSetPermissionedExtension.s.sol
@@ -2,8 +2,8 @@
 
 pragma solidity 0.8.26;
 
-import { console } from "../../lib/forge-std/src/console.sol";
-import { ScriptBase } from "../ScriptBase.s.sol";
+import { console } from "forge-std/console.sol";
+
 import { MultiSigBatchBase } from "../../lib/common/script/MultiSigBatchBase.sol";
 import { ISwapFacility } from "../../src/swap/interfaces/ISwapFacility.sol";
 

--- a/script/execute/ProposeSetPermissionedMSwapper.s.sol
+++ b/script/execute/ProposeSetPermissionedMSwapper.s.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity 0.8.26;
+
+import { console } from "../../lib/forge-std/src/console.sol";
+import { ScriptBase } from "../ScriptBase.s.sol";
+import { MultiSigBatchBase } from "../../lib/common/script/MultiSigBatchBase.sol";
+import { ISwapFacility } from "../../src/swap/interfaces/ISwapFacility.sol";
+
+/**
+ * @title ProposeSetPermissionedMSwapper
+ * @notice Proposes a multisig transaction to set a permissioned MSwapper on SwapFacility.
+ * @dev Requires env vars: PRIVATE_KEY, SWAP_FACILITY_ADDRESS, EXTENSION_ADDRESS, SWAPPER_ADDRESS, SAFE_ADDRESS
+ *      Usage: make set-permissioned-mswapper RPC_URL=<rpc> SWAP_FACILITY_ADDRESS=<addr> EXTENSION_ADDRESS=<addr> SWAPPER_ADDRESS=<addr> SAFE_ADDRESS=<addr>
+ */
+contract ProposeSetPermissionedMSwapper is MultiSigBatchBase {
+    function run() external {
+        address proposer_ = vm.rememberKey(vm.envUint("PRIVATE_KEY"));
+        address swapFacility_ = vm.envAddress("SWAP_FACILITY_ADDRESS");
+        address extension_ = vm.envAddress("EXTENSION_ADDRESS");
+        address swapper_ = vm.envAddress("SWAPPER_ADDRESS");
+        address safe_ = vm.envAddress("SAFE_ADDRESS");
+
+        console.log("Chain ID:", block.chainid);
+        console.log("SwapFacility:", swapFacility_);
+        console.log("Extension:", extension_);
+        console.log("Swapper:", swapper_);
+        console.log("Safe multisig:", safe_);
+        console.log("Proposer:", proposer_);
+
+        _addToBatch(swapFacility_, abi.encodeCall(ISwapFacility.setPermissionedMSwapper, (extension_, swapper_, true)));
+
+        _simulateBatch(safe_);
+        _proposeBatch(safe_, proposer_);
+
+        console.log("setPermissionedMSwapper proposed to multisig.");
+    }
+}

--- a/script/execute/ProposeSetPermissionedMSwapper.s.sol
+++ b/script/execute/ProposeSetPermissionedMSwapper.s.sol
@@ -2,8 +2,8 @@
 
 pragma solidity 0.8.26;
 
-import { console } from "../../lib/forge-std/src/console.sol";
-import { ScriptBase } from "../ScriptBase.s.sol";
+import { console } from "forge-std/console.sol";
+
 import { MultiSigBatchBase } from "../../lib/common/script/MultiSigBatchBase.sol";
 import { ISwapFacility } from "../../src/swap/interfaces/ISwapFacility.sol";
 


### PR DESCRIPTION
## Summary
- Adds three post-deployment configuration scripts under `script/execute/`:
  - `EnableEarning.s.sol` — calls `IMExtension.enableEarning()` on a deployed extension proxy.
  - `ProposeSetPermissionedExtension.s.sol` — proposes a Safe multisig batch calling `ISwapFacility.setPermissionedExtension(extension, true)`.
  - `ProposeSetPermissionedMSwapper.s.sol` — proposes a Safe multisig batch calling `ISwapFacility.setPermissionedMSwapper(extension, swapper, true)`.
- Adds a new `# CONFIGURE (Post-deployment config actions)` section to the `Makefile` with three targets wiring the scripts above: `enable-earning`, `set-permissioned-extension`, `set-permissioned-mswapper`.

## Test plan
- [x] `forge build` succeeds (verified locally).
- [x] `make -n enable-earning ...` / `make -n set-permissioned-extension ...` / `make -n set-permissioned-mswapper ...` print well-formed `forge script` invocations with all required env vars wired through.
- [x] On a testnet: `make enable-earning RPC_URL=<testnet> PRIVATE_KEY=<key> EXTENSION_ADDRESS=<proxy>` enables earning on a deployed extension.
- [x] On a testnet: `make set-permissioned-extension ...` and `make set-permissioned-mswapper ...` propose the expected Safe transactions and the multisig sees them queued.